### PR TITLE
Fix bugsnag notification

### DIFF
--- a/lib/uniform_notifier/bugsnag.rb
+++ b/lib/uniform_notifier/bugsnag.rb
@@ -13,7 +13,9 @@ class UniformNotifier
         opt = {}
         opt = UniformNotifier.bugsnag if UniformNotifier.bugsnag.is_a?(Hash)
 
-        exception = Exception.new(data[:title])
+        message = data[:title]
+        message += data[:body] if data[:body]
+        exception = Exception.new(message)
         exception.set_backtrace(data[:backtrace]) if data[:backtrace]
         Bugsnag.notify(exception, opt.merge(grouping_hash: data[:body] || data[:title], notification: data))
       end

--- a/lib/uniform_notifier/bugsnag.rb
+++ b/lib/uniform_notifier/bugsnag.rb
@@ -10,14 +10,20 @@ class UniformNotifier
       protected
 
       def _out_of_channel_notify(data)
-        opt = {}
-        opt = UniformNotifier.bugsnag if UniformNotifier.bugsnag.is_a?(Hash)
-
-        message = data[:title]
-        message += data[:body] if data[:body]
-        exception = Exception.new(message)
+        exception = Exception.new(data[:title])
         exception.set_backtrace(data[:backtrace]) if data[:backtrace]
-        Bugsnag.notify(exception, opt.merge(grouping_hash: data[:body] || data[:title], notification: data))
+
+        return nil if data.empty?
+
+        Bugsnag.notify(exception) do |report|
+          report.severity = "warning"
+          report.add_tab(:bullet, data)
+          report.grouping_hash = data[:body] || data[:title]
+
+          if UniformNotifier.bugsnag.is_a?(Proc)
+            UniformNotifier.bugsnag.call(report)
+          end
+        end
       end
     end
   end

--- a/spec/uniform_notifier/bugsnag_spec.rb
+++ b/spec/uniform_notifier/bugsnag_spec.rb
@@ -8,47 +8,51 @@ end
 
 RSpec.describe UniformNotifier::BugsnagNotifier do
   let(:notification_data) { {} }
+  let(:report) { double('Bugsnag::Report') }
+  before do
+    allow(report).to receive(:severity=)
+    allow(report).to receive(:add_tab)
+    allow(report).to receive(:grouping_hash=)
+  end
   it 'should not notify bugsnag' do
     expect(Bugsnag).not_to receive(:notify)
     UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
   end
   context 'with string notification' do
-    let(:notification_data) { { user: 'user', title: 'notify bugsnag', url: 'URL', body: 'something' } }
-
-    it 'should notify bugsnag' do
-      expect(Bugsnag).to receive(:notify).with(
-        UniformNotifier::Exception.new(notification_data[:title] + notification_data[:body]),
-        grouping_hash: notification_data[:body],
-        notification: notification_data
-      )
-
-      UniformNotifier.bugsnag = true
-      UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
-    end
-
-    it 'should notify bugsnag with option' do
-      expect(Bugsnag).to receive(:notify).with(
-        UniformNotifier::Exception.new(notification_data[:title]  + notification_data[:body]),
-        foo: :bar,
-        grouping_hash: notification_data[:body],
-        notification: notification_data
-      )
-
-      UniformNotifier.bugsnag = { foo: :bar }
-      UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
-    end
-  end
-  context 'with hash notification' do
     let(:notification_data) { 'notify bugsnag' }
 
     it 'should notify bugsnag' do
       expect(Bugsnag).to receive(:notify).with(
-        UniformNotifier::Exception.new('notify bugsnag'),
-        grouping_hash: 'notify bugsnag',
-        notification: {
-          title: 'notify bugsnag'
-        }
-      )
+        UniformNotifier::Exception.new(notification_data)
+      ).and_yield(report)
+      expect(report).to receive(:severity=).with('warning')
+      expect(report).to receive(:add_tab).with(:bullet, title: notification_data)
+      expect(report).to receive(:grouping_hash=).with(notification_data)
+
+      UniformNotifier.bugsnag = true
+      UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
+    end
+
+    it 'should notify bugsnag with additional report configuration' do
+      expect(Bugsnag).to receive(:notify).with(
+        UniformNotifier::Exception.new(notification_data)
+      ).and_yield(report)
+      expect(report).to receive(:meta_data=).with(foo: :bar)
+
+      UniformNotifier.bugsnag = ->(report) { report.meta_data = { foo: :bar } }
+      UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
+    end
+  end
+  context 'with hash notification' do
+    let(:notification_data) { { user: 'user', title: 'notify bugsnag', url: 'URL', body: 'something' } }
+
+    it 'should notify bugsnag' do
+      expect(Bugsnag).to receive(:notify).with(
+        UniformNotifier::Exception.new(notification_data[:title])
+      ).and_yield(report)
+      expect(report).to receive(:severity=).with('warning')
+      expect(report).to receive(:add_tab).with(:bullet, notification_data)
+      expect(report).to receive(:grouping_hash=).with(notification_data[:body])
 
       UniformNotifier.bugsnag = true
       UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
@@ -56,15 +60,11 @@ RSpec.describe UniformNotifier::BugsnagNotifier do
 
     it 'should notify bugsnag with option' do
       expect(Bugsnag).to receive(:notify).with(
-        UniformNotifier::Exception.new('notify bugsnag'),
-        foo: :bar,
-        grouping_hash: 'notify bugsnag',
-        notification: {
-          title: 'notify bugsnag'
-        }
-      )
+        UniformNotifier::Exception.new(notification_data[:title])
+      ).and_yield(report)
+      expect(report).to receive(:meta_data=).with(foo: :bar)
 
-      UniformNotifier.bugsnag = { foo: :bar }
+      UniformNotifier.bugsnag = ->(report) { report.meta_data = { foo: :bar } }
       UniformNotifier::BugsnagNotifier.out_of_channel_notify(notification_data)
     end
   end

--- a/spec/uniform_notifier/bugsnag_spec.rb
+++ b/spec/uniform_notifier/bugsnag_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UniformNotifier::BugsnagNotifier do
 
     it 'should notify bugsnag' do
       expect(Bugsnag).to receive(:notify).with(
-        UniformNotifier::Exception.new(notification_data[:title]),
+        UniformNotifier::Exception.new(notification_data[:title] + notification_data[:body]),
         grouping_hash: notification_data[:body],
         notification: notification_data
       )
@@ -28,7 +28,7 @@ RSpec.describe UniformNotifier::BugsnagNotifier do
 
     it 'should notify bugsnag with option' do
       expect(Bugsnag).to receive(:notify).with(
-        UniformNotifier::Exception.new(notification_data[:title]),
+        UniformNotifier::Exception.new(notification_data[:title]  + notification_data[:body]),
         foo: :bar,
         grouping_hash: notification_data[:body],
         notification: notification_data


### PR DESCRIPTION
Je préfère avoir une validation auprès de vous d'abord avant de créer la PR.

Une chose, je me demande si avec l'ajout d'un tab si c'est toujours pertinent d'ajouter le body sur le message d'`Exception`. Si oui, je pense qu'on fera mieux d'apporter des changements pas sur `uniform_notifier` mais sur `bullet` et changer le titre de la notification pour ajouter le class concerné.

Concrètement, cela se traduit par :
```ruby
def title
  "... for #{klazz_associations_str}"
end
```
dans : 
- https://github.com/flyerhzm/bullet/blob/master/lib/bullet/notification/counter_cache.rb
- https://github.com/flyerhzm/bullet/blob/master/lib/bullet/notification/n_plus_one_query.rb
- https://github.com/flyerhzm/bullet/blob/master/lib/bullet/notification/unused_eager_loading.rb
